### PR TITLE
Release y_chromosome_split

### DIFF
--- a/src/uk/ac/sanger/npg/picard/SplitBamByChromosomes.java
+++ b/src/uk/ac/sanger/npg/picard/SplitBamByChromosomes.java
@@ -221,11 +221,6 @@ public class SplitBamByChromosomes extends PicardCommandLine {
 				} else {
 					unaligned = false;
 				}
-			} else { // one or both reads are unmapped
-				if ((EXCLUDE_UNALIGNED) && (SUBSET.contains(rec.getReferenceName()))) {
-					// FixMate has reset * Y or * Y to Y Y
-					destination = EXCLUDED_INDEX;
-				}
 			}
 		}
 		if (unaligned && EXCLUDE_UNALIGNED && destination==TARGET_INDEX) {

--- a/test/uk/ac/sanger/npg/picard/SplitBamByChromosomesUnitTest.java
+++ b/test/uk/ac/sanger/npg/picard/SplitBamByChromosomesUnitTest.java
@@ -164,82 +164,6 @@ public class SplitBamByChromosomesUnitTest {
     1		*		*		EXCLUDED
 
     */
-    
-    @Test
-    public void testxahuman_exclude_unaligned() throws IOException {
-    System.out.println("SplitBamByChromosomes instanceMain: xahuman test case, V=false, U=false");
-    
-    String[] splitPaths = {
-        "testdata/10503_1_human_split_by_chromosome_excluded.sam", 
-        "testdata/10503_1_human_split_by_chromosome_target.sam" };
-    String[] args = {
-        "I=testdata/bam/10503_1_fix_mate.sam",
-        "X="+splitPaths[0],
-        "T="+splitPaths[1],
-        "U=true",
-        "TMP_DIR=testdata/",
-        "VALIDATION_STRINGENCY=SILENT"
-    };
-    splitter.instanceMain(args);
-    System.out.println(splitter.getCommandLine());
- 
-    
-    String[] expectedReadNamesInExcluded = {
-    		"first_chimeric",		
-    		"twenty_twenty",
-    		"unmapped_other",
-    		"other_unmapped",
-    		"second_chimeric",
-    		"pair_unmapped",
-       		"first_unmapped", 
-    		"second_unmapped"
-    };
-    
-    String[] expectedReadNamesInTarget = {
-    		"MT_MT",
-    		"y_and_y"		
-    };
-    
-    assertEquals(8, expectedReadNamesInExcluded.length);
-    assertEquals(2, expectedReadNamesInTarget.length);
-    Arrays.sort(expectedReadNamesInExcluded);
-    Arrays.sort(expectedReadNamesInTarget);
-    
-    for (int i=0; i<2; i++) {
-    	
-        File splitFile = new File(splitPaths[i]);
-        splitFile.deleteOnExit();
-        assertTrue(splitFile.exists());
-     
-        IoUtil.assertFileIsReadable(splitFile);
-        final SAMFileReader check = new SAMFileReader(splitFile);
-        
-        ArrayList<String> readNamesInFile = new ArrayList<String>();
-        for (SAMRecord rec: check){
-        	String qname = rec.getReadName();
-        
-        	if (!readNamesInFile.contains(qname)){
-        		readNamesInFile.add(qname);
-        		System.out.println("Found qname " + qname + " in file " + i );
-        	}
-        }
-        
-        Collections.sort(readNamesInFile);        
-        Object[] readNames = readNamesInFile.toArray();
-
-        if (i == 0) {
-        	 System.out.println(splitPaths[0]+"\t checking read groups in excluded");
-        	 //assertEquals(8, readNamesInFile.toArray().length);
-             //assertArrayEquals(expectedReadNamesInExcluded, readNames);
-        }
-        else {
-            System.out.println(splitPaths[1]+"\t checking read groups in target");
-            assertEquals(2, readNamesInFile.toArray().length);
-            assertArrayEquals(expectedReadNamesInTarget, readNames);
-        }
-    }
-    
-}
 
     /*
  yhuman S=Y V=true
@@ -348,7 +272,6 @@ UNALIGN read1 read2 destination
         SplitBamByChromosomesUnitTest test = new SplitBamByChromosomesUnitTest();
         
         test.testxahuman();
-        test.testxahuman_exclude_unaligned();
         test.testyhuman();
     }
 


### PR DESCRIPTION
Functionality for new test and proposed fix for EXCLUDE_UNALIGNED = true and default S=Y,MT reversed for now: EXCLUDE_UNALIGNED may also be needed for specified SUBSET?
