### PR TITLE
Picard 1.96, PG lines, Split Y chromosome

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
-
+release-1.11
 - include PG field in new RG header records
+- use Picard 1.96 rather than 1.84
+- [Hinxton #354882] separate_y_chromosome_data
 
 release-1.10
 - bugfix for single fragment/read templates in AlignmentFilter


### PR DESCRIPTION
Add #52, #53, #55 to Changes.  Y chromosome split is done via a new V flag to SplitBamByChromosomes to allow the target and excluded files to be inverted with some modifications to behaviour.
