### PR TITLE
added functionality to generate read name prefix for HiSeqX runs

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+- Added function to read experiment name and computer name from runParameters file
+    used to generate read name prefix if config file does not exist, updated tests
+- Ignore N's in barcode sequence when looking for matches, updated tests
+
 release 1.16
 - AlignmentFilterTest.java, testChimericReads -
 -   compare deeply the content of json files with

--- a/src/uk/ac/sanger/npg/illumina/Lane.java
+++ b/src/uk/ac/sanger/npg/illumina/Lane.java
@@ -451,9 +451,19 @@ public class Lane {
         this.id = this.readInstrumentAndRunID();
         if(id == null){
             log.warn("Problems to read run id and instrument name from config file:" + this.baseCallsConfig);
-            this.id = "";
         }else{
             log.info("Instrument name and run id to be used as part of read name: " + this.id );
+        }
+        if(id == null){
+            this.id = this.readExperimentNameAndComputerName();
+            if(id == null){
+                log.warn("Problems to read experiment name and computer name from runParameter file");
+            }else{
+                log.info("Computer name and experiment name to be used as part of read name: " + this.id );
+            }
+        }
+        if(id == null){
+            this.id = "";
         }
         
         runfolderConfig = readRunfolder();
@@ -710,6 +720,37 @@ public class Lane {
             return null;
         }
         return instrument + "_" + runID;
+    }
+
+    /**
+     *
+     * @return experiment name with computer name as part of read name, for example, HX10_15235
+     */
+    public String readExperimentNameAndComputerName(){
+
+        String experimentName = null;
+        String computerName   = null;
+        if(this.runParametersDoc != null){
+          try {
+              XPathExpression e = xpath.compile("RunParameters/Setup/ExperimentName/text()");
+              Node n = (Node) e.evaluate(this.runParametersDoc, XPathConstants.NODE);
+              if (n != null) {
+                  experimentName = n.getNodeValue();
+                  e = xpath.compile("RunParameters/Setup/ComputerName/text()");
+                  n = (Node) e.evaluate(this.runParametersDoc, XPathConstants.NODE);
+                  if (n != null) {
+                      computerName = n.getNodeValue();
+                  }
+              }
+          } catch (XPathExpressionException ex) {
+              log.error("Problems to read experiment name and computer name from run parameter file: " + ex.getMessage() );
+          }
+        }
+        if(experimentName == null || computerName == null) {
+            log.warn("No experiment name or computer name returned.");
+            return null;
+        }
+        return computerName + "_" + experimentName;
     }
 
     /**

--- a/test/uk/ac/sanger/npg/illumina/LaneTest.java
+++ b/test/uk/ac/sanger/npg/illumina/LaneTest.java
@@ -458,6 +458,9 @@ public class LaneTest {
         System.out.println("readInstrumentAndRunID");
         assertEquals("lane.readInstrumentAndRunID()", null, lane.readInstrumentAndRunID());
 
+        System.out.println("readExperimentNameAndComputerName");
+        assertEquals("lane.readExperimentNameAndComputerName()", "HX1_ValB", lane.readExperimentNameAndComputerName());
+
         System.out.println("getCycleRangeByRead");
         HashMap<String,int[]> cycleRangeByRead = lane.getCycleRangeByRead();
         assertNotNull("getCycleRangeByRead()", cycleRangeByRead );


### PR DESCRIPTION
added function to read experiment name and computer name from runParameters file
used to generate read name prefix if config file does not exist
updated tests